### PR TITLE
Fix ace includes

### DIFF
--- a/src/html/index.mustache
+++ b/src/html/index.mustache
@@ -4,9 +4,9 @@
   <title>DoppioJVM: A JVM in JavaScript</title>
   <link href='http://fonts.googleapis.com/css?family=Bitter' rel='stylesheet'>
   <link rel='stylesheet' href="css/style.css">
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ace/1.1.01/ace.js" type="text/javascript"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ace/1.1.01/mode-java.js" type="text/javascript"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ace/1.1.01/theme-twilight.js" type="text/javascript"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/ace/1.1.01/ace.js" type="text/javascript" charset="utf-8"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/ace/1.1.01/mode-java.js" type="text/javascript" charset="utf-8"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/ace/1.1.01/theme-twilight.js" type="text/javascript" charset="utf-8"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/dropbox.js/0.10.2/dropbox.min.js" type="text/javascript"></script>
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery-migrate/1.2.1/jquery-migrate.min.js"></script>


### PR DESCRIPTION
Previously, the demo exhibited this behavior: http://stackoverflow.com/questions/17108641/typing-spaces-in-ace-editor-results-in-special-characters

Now it doesn't.
