### PR TITLE
Create `programs` dir if it doesn't exist

### DIFF
--- a/tasks/listings.ts
+++ b/tasks/listings.ts
@@ -6,16 +6,27 @@ function listings(grunt: IGrunt) {
     var done: (status?: boolean) => void = this.async(),
       cwd = process.cwd(),
       options = this.options();
+
+    // Make sure that `programs` folder exists.
     grunt.util.spawn({
-      cmd: 'node',
-      args: [`${cwd}/node_modules/coffee-script/bin/coffee`, `${cwd}/node_modules/browserfs/tools/XHRIndexer.coffee`],
-      opts: {cwd: options.cwd}
+      cmd: 'mkdir',
+      args: ['-p', options.cwd]
     }, function(error: Error, result: grunt.util.ISpawnResult, code: number) {
       if (code !== 0 || error) {
-        grunt.fail.fatal("Error generating listings.json: " + result.stderr + error);
+        grunt.fail.fatal("Error creating needed directory for listings.json: " + result.stderr + error);
       }
-      fs.writeFileSync(options.output, result.stdout);
-      done();
+
+      grunt.util.spawn({
+        cmd: 'node',
+        args: [`${cwd}/node_modules/coffee-script/bin/coffee`, `${cwd}/node_modules/browserfs/tools/XHRIndexer.coffee`],
+        opts: {cwd: options.cwd}
+      }, function(error: Error, result: grunt.util.ISpawnResult, code: number) {
+        if (code !== 0 || error) {
+          grunt.fail.fatal("Error generating listings.json: " + result.stderr + error);
+        }
+        fs.writeFileSync(options.output, result.stdout);
+        done();
+      });
     });
   });
 }


### PR DESCRIPTION
In a clean `build` directory, there is no `programs` dir so create if needed.